### PR TITLE
Update bugsnag (v1 to v2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const winston = require('winston');
 const util = require('util');
 
 function BugsnagLogger(options) {
-
   options = options || {};
   options = _.defaultsDeep(options, {
     apiKey: process.env.BUGSNAG_API_KEY || '',
@@ -37,9 +36,19 @@ function BugsnagLogger(options) {
     this.bugsnag = options.bugsnag;
   } else {
     this.bugsnag = bugsnag;
+
+    // bugsnag-node 2.1.2:
+    // sessionTrackingEnabled renamed as autoCaptureSessions
+    if (_.has(options, 'config.sessionTrackingEnabled')) {
+      _.set(
+        options,
+        'config.autoCaptureSessions',
+        _.get(options, 'config.sessionTrackingEnabled')
+      );
+    }
+
     this.bugsnag.register(options.apiKey, options.config);
   }
-
 };
 
 // Inherit from `winston.Transport`
@@ -50,7 +59,6 @@ util.inherits(BugsnagLogger, winston.Transport);
 winston.transports.BugsnagLogger = BugsnagLogger;
 
 BugsnagLogger.prototype.log = function(level, msg, meta, fn) {
-
   if (this.silent) return fn(null, true);
   if (!(level in this._levelsMap)) return fn(null, true);
 
@@ -78,7 +86,6 @@ BugsnagLogger.prototype.log = function(level, msg, meta, fn) {
   this.bugsnag.notify(msg, meta, function() {
     fn(null, true);
   });
-
 }
 
 module.exports = BugsnagLogger;

--- a/index.js
+++ b/index.js
@@ -62,8 +62,20 @@ BugsnagLogger.prototype.log = function(level, msg, meta, fn) {
   if (this.silent) return fn(null, true);
   if (!(level in this._levelsMap)) return fn(null, true);
 
+  var severity = this._levelsMap[level];
+
+  if (_.isError(meta)) {
+    // bugsnag expects instances of `Error` as a first argument;
+    // otherwise, the wrong stack is tracked
+    this.bugsnag.notify(meta, {
+      message: msg,
+      severity: severity,
+    });
+    return fn(null, true);
+  }
+
   meta = meta || {};
-  meta.severity = this._levelsMap[level];
+  meta.severity = severity;
   meta.metaData = meta.metaData || {};
 
   //

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "winston-bugsnag-logger",
   "description": "The maintained and well-documented Bugsnag transport for the winston logger",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "Nick Baugh",
   "bugs": {
     "url": "https://github.com/niftylettuce/winston-bugsnag-logger/issues"
   },
   "dependencies": {
-    "bugsnag": "^1.12.0",
+    "bugsnag": "^2.1.3",
     "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "winston": "^2.3.1"
+    "winston": "^2.4.0"
   },
   "engines": {
     "node": ">= 4.8.4"


### PR DESCRIPTION
Hi

That's a very quick/simple PR in order to use the very last version of bugsnag-node, as it fixes a significant amount of bugs since the v[1.12](https://github.com/bugsnag/bugsnag-node/blob/master/CHANGELOG.md#1122-2017-09-13).
I also tried to ensure that no project would break because of a property renamed in v[2.1.2](https://github.com/bugsnag/bugsnag-node/blob/master/CHANGELOG.md#212-2018-01-09). 

Please let me know if I can do anything else.